### PR TITLE
Improved test failure display on the ScalaTest View

### DIFF
--- a/org.scala-ide.sdt.scalatest.tests/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegateTest.scala
+++ b/org.scala-ide.sdt.scalatest.tests/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegateTest.scala
@@ -10,17 +10,12 @@ import org.eclipse.debug.internal.core.LaunchConfiguration
 import org.mockito.Matchers
 import org.mockito.Mockito
 import org.junit.runner.RunWith
-//import org.powermock.modules.junit4.PowerMockRunner
-//import org.powermock.core.classloader.annotations.PrepareForTest
-//import org.powermock.api.mockito.PowerMockito
 
 /**
  * We need PowerMock because <code>ScalaTestLaunchDelegate</code> cannot be mocked with Mockito (its superclass is in a signed Jar file).
  *
  * @author rlegendi
  */
-//@RunWith(classOf[PowerMockRunner])
-//@PrepareForTest(Array(classOf[ScalaTestLaunchDelegate]))
 class ScalaTestLaunchDelegateTest {
 
   // --------------------------------------------------------------------------
@@ -54,7 +49,7 @@ class ScalaTestLaunchDelegateTest {
     def res = delegate.escapeScalaTestClasspathComponent("Program files")
     assertEquals("Program\\ files", res)
   }
-  
+
   @Test
   def testEscapingForClassPathEntryWithDoubleSpaces() {
     def delegate = new ScalaTestLaunchDelegate
@@ -87,11 +82,9 @@ class ScalaTestLaunchDelegateTest {
     when(config.getAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "")).thenReturn("testpkg")
     when(config.getAttribute(SCALATEST_LAUNCH_INCLUDE_NESTED_NAME, INCLUDE_NESTED_FALSE)).thenReturn(INCLUDE_NESTED_TRUE)
 
-    //val delegate = mock(classOf[ScalaTestLaunchDelegate])
     val delegate = new ScalaTestLaunchDelegate() {
       override def getClasspath(configuration: ILaunchConfiguration): Array[String] = cps.toArray
     }
-    //doReturn(cps.toArray[String]).when(delegate).getClasspath(config)
 
     delegate.getScalaTestArgs(config)
   }

--- a/org.scala-ide.sdt.scalatest.tests/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegateTest.scala
+++ b/org.scala-ide.sdt.scalatest.tests/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegateTest.scala
@@ -1,0 +1,129 @@
+package scala.tools.eclipse.scalatest.launching
+
+import org.junit.Test
+import org.junit.Assert._
+import org.mockito.Mockito._
+import org.eclipse.debug.core.ILaunchConfiguration
+import ScalaTestLaunchConstants._
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants
+import org.eclipse.debug.internal.core.LaunchConfiguration
+import org.mockito.Matchers
+import org.mockito.Mockito
+import org.junit.runner.RunWith
+//import org.powermock.modules.junit4.PowerMockRunner
+//import org.powermock.core.classloader.annotations.PrepareForTest
+//import org.powermock.api.mockito.PowerMockito
+
+/**
+ * We need PowerMock because <code>ScalaTestLaunchDelegate</code> cannot be mocked with Mockito (its superclass is in a signed Jar file).
+ *
+ * @author rlegendi
+ */
+//@RunWith(classOf[PowerMockRunner])
+//@PrepareForTest(Array(classOf[ScalaTestLaunchDelegate]))
+class ScalaTestLaunchDelegateTest {
+
+  // --------------------------------------------------------------------------
+  // Escaping test
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testEscapingForNullClassPathEntry() {
+    // TODO These might be static methods in a companion object
+    def delegate = new ScalaTestLaunchDelegate
+    delegate.escapeScalaTestClasspathComponent(null)
+  }
+
+  @Test
+  def testEscapingForEmptyClassPathEntry() {
+    def delegate = new ScalaTestLaunchDelegate
+    def res = delegate.escapeScalaTestClasspathComponent("")
+    assertEquals("", res)
+  }
+
+  @Test
+  def testEscapingForSimpleClassPathEntry() {
+    def delegate = new ScalaTestLaunchDelegate
+    def res = delegate.escapeScalaTestClasspathComponent("some.jar")
+    assertEquals("some.jar", res)
+  }
+
+  @Test
+  def testEscapingForClassPathEntryWithSingleSpace() {
+    def delegate = new ScalaTestLaunchDelegate
+
+    def res = delegate.escapeScalaTestClasspathComponent("Program files")
+    assertEquals("Program\\ files", res)
+  }
+  
+  @Test
+  def testEscapingForClassPathEntryWithDoubleSpaces() {
+    def delegate = new ScalaTestLaunchDelegate
+
+    def res = delegate.escapeScalaTestClasspathComponent("Program  files")
+    assertEquals("Program\\ \\ files", res)
+  }
+
+  @Test
+  def testEscapingForClassPathEntryWithDoubleQuotes() {
+    def delegate = new ScalaTestLaunchDelegate
+
+    def res = delegate.escapeScalaTestClasspathComponent("middle\"escaped")
+    assertEquals("middle\\\"escaped", res)
+  }
+
+  // --------------------------------------------------------------------------
+  // ScalaTest argument building test
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def argsBuildingForNull() {
+    def delegate = new ScalaTestLaunchDelegate
+    delegate.getScalaTestArgs(null)
+  }
+
+  private def evalScalaTestArgs(cps: String*): String = {
+    val config = mock(classOf[ILaunchConfiguration])
+
+    when(config.getAttribute(SCALATEST_LAUNCH_TYPE_NAME, TYPE_SUITE)).thenReturn(TYPE_PACKAGE)
+    when(config.getAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "")).thenReturn("testpkg")
+    when(config.getAttribute(SCALATEST_LAUNCH_INCLUDE_NESTED_NAME, INCLUDE_NESTED_FALSE)).thenReturn(INCLUDE_NESTED_TRUE)
+
+    //val delegate = mock(classOf[ScalaTestLaunchDelegate])
+    val delegate = new ScalaTestLaunchDelegate() {
+      override def getClasspath(configuration: ILaunchConfiguration): Array[String] = cps.toArray
+    }
+    //doReturn(cps.toArray[String]).when(delegate).getClasspath(config)
+
+    delegate.getScalaTestArgs(config)
+  }
+
+  @Test
+  def argsBuildingForEmptyClassPath() {
+    val res = evalScalaTestArgs("")
+    assertEquals("-p \"\" -w testpkg", res)
+  }
+
+  @Test
+  def argsBuildingForSingleClassPath() {
+    val res = evalScalaTestArgs("some.jar")
+    assertEquals("-p \"some.jar\" -w testpkg", res)
+  }
+
+  @Test
+  def argsBuildingForMultipleSimpleClassPath() {
+    val res = evalScalaTestArgs("some.jar", "other.jar")
+    assertEquals("-p \"some.jar other.jar\" -w testpkg", res)
+  }
+
+  @Test
+  def argsBuildingForFolderAndJarClassPath() {
+    val res = evalScalaTestArgs("some/folder", "and/", "some.jar")
+    assertEquals("-p \"some/folder and/ some.jar\" -w testpkg", res)
+  }
+
+  @Test
+  def argsBuildingForSingleSpacedClassPath() {
+    val res = evalScalaTestArgs("some.jar", "and a spaced folder", "andSomething/else")
+    assertEquals("-p \"some.jar and\\ a\\ spaced\\ folder andSomething/else\" -w testpkg", res)
+  }
+
+}

--- a/org.scala-ide.sdt.scalatest/.classpath
+++ b/org.scala-ide.sdt.scalatest/.classpath
@@ -5,6 +5,6 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/home/cheeseng/git/scalatest-eclipse-plugin/org.scala-ide.sdt.scalatest/target/lib/scalatest-finders_2.9.0-0.9.2-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="target/lib/scalatest-finders_2.9.0-0.9.2-SNAPSHOT.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegate.scala
+++ b/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegate.scala
@@ -233,7 +233,8 @@ class ScalaTestLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
           ""
       case TYPE_PACKAGE =>
         val packageName = configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "")
-        val workspace = ResourcesPlugin.getWorkspace()
+        // Reference for the workspace should be omitted, tests fail with an java.lang.IllegalStateException: Workspace is closed. error message
+        //val workspace = ResourcesPlugin.getWorkspace()
         val outputDir = getClasspath(configuration).foldLeft("")((acc, act) => acc + " " + escapeScalaTestClasspathComponent(act)).trim
         if (packageName.length > 0) {
           val includeNested = configuration.getAttribute(SCALATEST_LAUNCH_INCLUDE_NESTED_NAME, INCLUDE_NESTED_FALSE)

--- a/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegate.scala
+++ b/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchDelegate.scala
@@ -180,18 +180,6 @@ class ScalaTestLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
     bootEntry.toList.map(_.getLocation())
   }
   
-  /**
-   * Simple utility function that processes a classpath element for the ScalaTest Runner class.
-   * 
-   * <p>
-   * Basically, the only task to do here is to escape each whitespace and double quote characters. 
-   * </p>
-   * 
-   * @param comp a classpath component as a string 
-   * @return a properly escaped version of parameter <code>comp</code> 
-   * @see <a href="http://www.scalatest.org/scaladoc/1.8/org/scalatest/tools/Runner$.html">Runner</a> (see section "Specifying a runpath")
-   * @author rlegendi
-   */
   // TODO Needs an expert's review
   private[launching] def escapeScalaTestClasspathComponent(comp: String): String = {
     require(comp != null)
@@ -229,8 +217,6 @@ class ScalaTestLaunchDelegate extends AbstractJavaLaunchConfigurationDelegate {
           ""
       case TYPE_PACKAGE =>
         val packageName = configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "")
-        // Reference for the workspace should be omitted, tests fail with an java.lang.IllegalStateException: Workspace is closed. error message
-        //val workspace = ResourcesPlugin.getWorkspace()
         val outputDir = getClasspath(configuration).foldLeft("")((acc, act) => acc + " " + escapeScalaTestClasspathComponent(act)).trim
         if (packageName.length > 0) {
           val includeNested = configuration.getAttribute(SCALATEST_LAUNCH_INCLUDE_NESTED_NAME, INCLUDE_NESTED_FALSE)


### PR DESCRIPTION
Hi all!

Hope this is the proper repo to submit any pull requests :-) I'm working on the [Specs2 integration through ScalaTest plugin](http://rlegendi.github.com/specs2-runner/) and got a feedback about [a minor issue](https://github.com/rlegendi/specs2-runner/issues/2). I thought the best approach would be to extend the ScalaTest plugin so everyone could benefit from the patch.

The issue is that if a test if failed, its reason is not reported in any way at the ScalaTest view.

The default Eclipse JUnit runner view for instance, looks like this:

![How JUnit View works](https://raw.github.com/rlegendi/specs2-runner/master/doc/issues/002/junit.png)

Now, the ScalaTest view had nothing similar:

![How the ScalaTest view worked so far](https://raw.github.com/rlegendi/specs2-runner/master/doc/issues/002/stacktrace.png)

So in this pull request I extended the view with the proper error message display that caused the test to fail:

![My new cool freature](https://raw.github.com/rlegendi/specs2-runner/master/doc/issues/002/ok_stacktrace.png)

I would also welcome any code review, because after many modifications I still feel the addition a bit clumsy [here](https://github.com/scalatest/scalatest-eclipse-plugin/pull/11/files#L2R86) and [here](https://github.com/scalatest/scalatest-eclipse-plugin/pull/11/files#L2R157). Thanks in advance!

I have also found an absolute library reference in the project classpath entries, changed it to relative (so after checking out the project it has no errors hopefully).

Thanks in advance!
