### PR TITLE
enhancement to run scalatest test with ScalaRunner

### DIFF
--- a/org.scala-ide.sdt.scalatest.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.scalatest.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.scala-lang.scala-library,
  org.eclipse.equinox.weaving.aspectj,
  org.junit,
- org.scala-ide.sdt.core
+ org.scala-ide.sdt.core,
+ org.scala-ide.sdt.debug
 Import-Package: org.scalaide.core.testsetup,
  org.aspectj.weaver.loadtime.definition
 Bundle-ClassPath: .,

--- a/org.scala-ide.sdt.scalatest.tests/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchTest.scala
+++ b/org.scala-ide.sdt.scalatest.tests/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchTest.scala
@@ -51,9 +51,9 @@ class ScalaTestLaunchTest {
 
   import ScalaTestProject._
 
-  private def launch(launchName: String) {
+  private def launch(launchName: String, mode: String = ILaunchManager.RUN_MODE) {
     val launchConfig = DebugPlugin.getDefault.getLaunchManager.getLaunchConfiguration(file(launchName + ".launch"))
-    launchConfig.launch(ILaunchManager.RUN_MODE, null)
+    launchConfig.launch(mode, null)
   }
 
   @Test
@@ -124,6 +124,146 @@ class ScalaTestLaunchTest {
   @Test
   def `testLaunchConfigcom.test.TestingFunSuite-'test2'`() {
     launch("com.test.TestingFunSuite-'test2'")
+  }
+
+  @Test
+  def testLaunchComTestPackageWithScalaRunner() {
+    launch("com.test.scalarunner")
+  }
+
+  @Test
+  def testLaunchComTestPackageWithScalaDebugger() {
+    launch("com.test.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchSingleSpecFileWithScalaRunner() {
+    launch("SingleSpec.scala.scalarunner")
+  }
+
+  @Test
+  def testLaunchSingleSpecFileWithScalaDebugger() {
+    launch("SingleSpec.scala.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchMultiSpecFileWithScalaRunner() {
+    launch("MultiSpec.scala.scalarunner")
+  }
+
+  @Test
+  def testLaunchMultiSpecFileWithScalaDebugger() {
+    launch("MultiSpec.scala.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchSingleSpecWithScalaRunner() {
+    launch("SingleSpec.scalarunner")
+  }
+
+  @Test
+  def testLaunchSingleSpecWithScalaDebugger() {
+    launch("SingleSpec.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchStackSpec2WithScalaRunner() {
+    launch("StackSpec2.scalarunner")
+  }
+
+  @Test
+  def testLaunchStackSpec2WithScalaDebugger() {
+    launch("StackSpec2.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchTestingFreeSpecWithScalaRunner() {
+    launch("TestingFreeSpec.scalarunner")
+  }
+
+  @Test
+  def testLaunchTestingFreeSpecWithScalaDebugger() {
+    launch("TestingFreeSpec.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchTestingFunSuiteWithScalaRunner() {
+    launch("TestingFunSuite.scalarunner")
+  }
+
+  @Test
+  def testLaunchTestingFunSuiteWithScalaDebugger() {
+    launch("TestingFunSuite.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchConfigAStackshouldtastelikepeanutbutterWithScalaRunner() {
+    launch("AStackshouldtastelikepeanutbutter.scalarunner")
+  }
+
+  @Test
+  def testLaunchConfigAStackshouldtastelikepeanutbutterWithScalaDebugger() {
+    launch("AStackshouldtastelikepeanutbutter.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchConfigAStackwhenemptyshouldcomplainonpopWithScalaRunner() {
+    launch("AStackwhenemptyshouldcomplainonpop.scalarunner")
+  }
+
+  @Test
+  def testLaunchConfigAStackwhenemptyshouldcomplainonpopWithScalaDebugger() {
+    launch("AStackwhenemptyshouldcomplainonpop.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchConfigAStackwhenfullWithScalaRunner() {
+    launch("AStackwhenfull.scalarunner")
+  }
+
+  @Test
+  def testLaunchConfigAStackwhenfullWithScalaDebugger() {
+    launch("AStackwhenfull.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchConfigAStackwheneveritisemptycertainlyoughttocomplainonpeekWithScalaRunner() {
+    launch("AStackwheneveritisemptycertainlyoughttocomplainonpeek.scalarunner")
+  }
+
+  @Test
+  def testLaunchConfigAStackwheneveritisemptycertainlyoughttocomplainonpeekWithScalaDebugger() {
+    launch("AStackwheneveritisemptycertainlyoughttocomplainonpeek.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchConfigAStackwheneveritisemptyWithScalaRunner() {
+    launch("AStackwheneveritisempty.scalarunner")
+  }
+
+  @Test
+  def testLaunchConfigAStackwheneveritisemptyWithScalaDebugger() {
+    launch("AStackwheneveritisempty.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def testLaunchConfigAStackWithScalaRunner() {
+    launch("AStack.scalarunner")
+  }
+
+  @Test
+  def testLaunchConfigAStackWithScalaDebugger() {
+    launch("AStack.scalarunner", ILaunchManager.DEBUG_MODE)
+  }
+
+  @Test
+  def `testLaunchConfigcom.test.TestingFunSuite-'test2'WithScalaRunner`() {
+    launch("com.test.TestingFunSuite-'test2'.scalarunner")
+  }
+
+  @Test
+  def `testLaunchConfigcom.test.TestingFunSuite-'test2'WithScalaDebugger`() {
+    launch("com.test.TestingFunSuite-'test2'.scalarunner", ILaunchManager.DEBUG_MODE)
   }
 
   @Ignore

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStack.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStack.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.SingleSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStack.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStack.scalarunner.launch
@@ -4,15 +4,15 @@
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/SingleSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.SingleSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackshouldtastelikepeanutbutter.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackshouldtastelikepeanutbutter.launch
@@ -11,6 +11,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.SingleSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackshouldtastelikepeanutbutter.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackshouldtastelikepeanutbutter.scalarunner.launch
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
-<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
+<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME">
+<setEntry value="A Stack should taste like peanut butter"/>
+</setAttribute>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/SingleSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.SingleSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenemptyshouldcomplainonpop.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenemptyshouldcomplainonpop.launch
@@ -11,6 +11,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StackSpec2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenemptyshouldcomplainonpop.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenemptyshouldcomplainonpop.scalarunner.launch
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
-<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
+<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME">
+<setEntry value="A Stack when empty should complain on pop"/>
+</setAttribute>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StackSpec2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisempty.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisempty.launch
@@ -13,6 +13,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFreeSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisempty.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisempty.scalarunner.launch
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
-<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
+<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME">
+<setEntry value="A Stack whenever it is empty certainly ought to be empty"/>
+<setEntry value="A Stack whenever it is empty certainly ought to complain on peek"/>
+<setEntry value="A Stack whenever it is empty certainly ought to complain on pop"/>
+</setAttribute>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFreeSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisemptycertainlyoughttocomplainonpeek.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisemptycertainlyoughttocomplainonpeek.launch
@@ -11,6 +11,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFreeSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisemptycertainlyoughttocomplainonpeek.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwheneveritisemptycertainlyoughttocomplainonpeek.scalarunner.launch
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
-<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
+<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME">
+<setEntry value="A Stack whenever it is empty certainly ought to complain on peek"/>
+</setAttribute>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFreeSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenfull.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenfull.launch
@@ -12,6 +12,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StackSpec2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenfull.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/AStackwhenfull.scalarunner.launch
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
-<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
+<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME">
+<setEntry value="A Stack when full should be full"/>
+<setEntry value="A Stack when full should complain on push"/>
+</setAttribute>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StackSpec2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/ExampleSpec1.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/ExampleSpec1.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.ExampleSpec1"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/ExampleSpec1.scala.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/ExampleSpec1.scala.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="/scalatest/src/com/test/ExampleSpec1.scala"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/MultiSpec.scala.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/MultiSpec.scala.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="/scalatest/src/com/test/MultiSpec.scala"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/MultiSpec.scala.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/MultiSpec.scala.scalarunner.launch
@@ -2,17 +2,17 @@
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
-<stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
+<stringAttribute key="SCALATEST_LAUNCH_TYPE" value="FILE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
+<listEntry value="4"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="/scalatest/src/com/test/MultiSpec.scala"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/Mysystem.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/Mysystem.launch
@@ -12,6 +12,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.ExampleSpec1"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/Mysystemalsocanprovidesadvancedfeature1.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/Mysystemalsocanprovidesadvancedfeature1.launch
@@ -11,6 +11,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.ExampleSpec1"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.SingleSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.scala.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.scala.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="/scalatest/src/com/test/SingleSpec.scala"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.scala.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.scala.scalarunner.launch
@@ -2,17 +2,17 @@
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
-<stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
+<stringAttribute key="SCALATEST_LAUNCH_TYPE" value="FILE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
+<listEntry value="4"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="/scalatest/src/com/test/SingleSpec.scala"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/SingleSpec.scalarunner.launch
@@ -4,15 +4,15 @@
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/SingleSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.SingleSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/StackSpec2.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/StackSpec2.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StackSpec2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/StackSpec2.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/StackSpec2.scalarunner.launch
@@ -4,15 +4,15 @@
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StackSpec2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/StringSpecification.scala.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/StringSpecification.scala.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="/scalatest/src/com/test/StringSpecification.scala"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFreeSpec.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFreeSpec.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFreeSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFreeSpec.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFreeSpec.scalarunner.launch
@@ -4,15 +4,15 @@
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFreeSpec"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFunSuite.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFunSuite.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFunSuite"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFunSuite.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/TestingFunSuite.scalarunner.launch
@@ -4,15 +4,15 @@
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFunSuite"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.StringSpecification-'substring1'.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.StringSpecification-'substring1'.launch
@@ -11,6 +11,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.TestingFunSuite-'test2'.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.TestingFunSuite-'test2'.launch
@@ -11,6 +11,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFunSuite"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.TestingFunSuite-'test2'.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.TestingFunSuite-'test2'.scalarunner.launch
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
-<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
+<setAttribute key="SCALATEST_LAUNCH_TESTS_NAME">
+<setEntry value="test 2"/>
+</setAttribute>
 <stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest/src/com/test/MultiSpec.scala"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.TestingFunSuite"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.launch
@@ -9,6 +9,10 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.scalarunner.launch
+++ b/org.scala-ide.sdt.scalatest.tests/test-workspace/scalatest/com.test.scalarunner.launch
@@ -2,17 +2,17 @@
 <launchConfiguration type="scala.scalatest">
 <stringAttribute key="SCALATEST_LAUNCH_INCLUDE_NESTED" value="false"/>
 <setAttribute key="SCALATEST_LAUNCH_TESTS_NAME"/>
-<stringAttribute key="SCALATEST_LAUNCH_TYPE" value="SUITE"/>
+<stringAttribute key="SCALATEST_LAUNCH_TYPE" value="PACKAGE"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/scalatest/src/com/test/StringSpecification.scala"/>
+<listEntry value="/scalatest"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
+<listEntry value="4"/>
 </listAttribute>
 <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="scala.scalatest.javarunner"/>
-<mapEntry key="[debug]" value="scala.scalatest.javarunner"/>
+<mapEntry key="[run]" value="scala.scalatest.scalarunner"/>
+<mapEntry key="[debug]" value="scala.scalatest.scalarunner"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test.StringSpecification"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="scalatest"/>
 </launchConfiguration>

--- a/org.scala-ide.sdt.scalatest/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.scalatest/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Require-Bundle:
  org.scala-lang.scala-compiler;bundle-version="[2.11.0,2.12.0)",
  org.scala-lang.scala-reflect,
  org.scala-ide.sdt.core;bundle-version="[4.0.0,5.0.0)",
+ org.scala-ide.sdt.debug;bundle-version="[4.2.0,5.0.0)",
  org.scala-lang.modules.scala-xml;bundle-version="1.0.0"
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,

--- a/org.scala-ide.sdt.scalatest/plugin.xml
+++ b/org.scala-ide.sdt.scalatest/plugin.xml
@@ -8,14 +8,27 @@
            id="scala.scalatest"
            delegate="scala.tools.eclipse.scalatest.launching.ScalaTestLaunchDelegate"
            delegateDescription="The ScalaTest Launcher supports running and debugging tests written in ScalaTest."
-           delegateName="ScalaTest Launcher"
+           name="ScalaTest (java runner)"
            modes="run, debug"
-           name="ScalaTest"
-           public="true"
            sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector"
            sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer">
     </launchConfigurationType>
   
+  </extension>
+  
+  <extension point="org.eclipse.debug.core.launchDelegates">
+  
+    <launchDelegate
+           id="scala.scalatest.scalarunner"
+           delegate="scala.tools.eclipse.scalatest.launching.ScalaTestScalaLaunchDelegate"
+           delegateDescription="The ScalaTest Launcher supports running and debugging tests written in ScalaTest with Scala Expression Evaluator."
+           name="ScalaTest (scala runner)"
+           modes="debug"
+           sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector"
+           sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer"
+           type="scala.scalatest">
+    </launchDelegate>
+    
   </extension>
   
   <extension point="org.eclipse.debug.ui.launchConfigurationTypeImages">
@@ -35,7 +48,7 @@
         class="scala.tools.eclipse.scalatest.launching.ScalaTestTabGroup"
         id="scala.scalatest.tabGroup">
     </launchConfigurationTabGroup>
-    
+   
   </extension>
   
   <extension point="org.eclipse.core.expressions.propertyTesters">

--- a/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchableTester.scala
+++ b/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestLaunchableTester.scala
@@ -78,7 +78,7 @@ class ScalaTestTestTester extends PropertyTester {
           }
         }
         catch {
-          case _ => false
+          case _: Throwable => false
         }
       case _ =>
         false
@@ -120,7 +120,7 @@ class ScalaTestSuiteTester extends PropertyTester {
       }
     }
     catch {
-      case _ => false
+      case _: Throwable => false
     }
   }
 }
@@ -147,7 +147,7 @@ class ScalaTestFileTester extends PropertyTester {
       }
     }
     catch {
-      case _ => false
+      case _: Throwable => false
     }
   }
 }

--- a/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestMainTab.scala
+++ b/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestMainTab.scala
@@ -36,67 +36,51 @@
 
 package scala.tools.eclipse.scalatest.launching
 
-import org.eclipse.jdt.debug.ui.launchConfigurations.JavaMainTab
-import org.eclipse.swt.widgets.Composite
-import org.eclipse.swt.widgets.Group
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
 import org.eclipse.debug.internal.ui.SWTFactory
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.core.IType
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.core.JavaModelException
+import org.eclipse.jdt.internal.debug.ui.IJavaDebugHelpContextIds
+import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin
+import org.eclipse.jdt.internal.debug.ui.launcher.DebugTypeSelectionDialog
+import org.eclipse.jdt.internal.debug.ui.launcher.LauncherMessages
+import org.eclipse.jdt.internal.debug.ui.launcher.SharedJavaMainTab
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants
+import org.eclipse.jdt.ui.ISharedImages
+import org.eclipse.jdt.ui.JavaUI
+import org.eclipse.jface.viewers.LabelProvider
+import org.eclipse.jface.window.Window
+import org.eclipse.swt.SWT
+import org.eclipse.swt.custom.TableEditor
+import org.eclipse.swt.events.ModifyEvent
+import org.eclipse.swt.events.ModifyListener
+import org.eclipse.swt.events.SelectionAdapter
+import org.eclipse.swt.events.SelectionEvent
+import org.eclipse.swt.events.SelectionListener
 import org.eclipse.swt.layout.GridData
 import org.eclipse.swt.layout.GridLayout
-import org.eclipse.ui.PlatformUI
-import org.eclipse.jdt.internal.debug.ui.IJavaDebugHelpContextIds
-import org.eclipse.swt.widgets.Text
 import org.eclipse.swt.widgets.Button
-import org.eclipse.swt.events.ModifyListener
-import org.eclipse.swt.events.ModifyEvent
-import org.eclipse.jdt.internal.debug.ui.actions.ControlAccessibleListener
-import org.eclipse.jdt.internal.debug.ui.launcher.LauncherMessages
-import org.eclipse.swt.events.SelectionListener
-import org.eclipse.swt.events.SelectionEvent
-import org.eclipse.jdt.internal.debug.ui.launcher.SharedJavaMainTab
-import org.eclipse.swt.graphics.Image
-import org.eclipse.jdt.ui.JavaUI
-import org.eclipse.jdt.ui.ISharedImages
-import org.eclipse.jdt.core.IJavaProject
-import org.eclipse.jdt.core.IJavaElement
-import org.eclipse.jdt.core.JavaCore
-import org.eclipse.core.resources.ResourcesPlugin
-import org.eclipse.jdt.core.JavaModelException
-import org.eclipse.jdt.internal.debug.ui.JDIDebugUIPlugin
-import org.eclipse.jdt.core.search.IJavaSearchScope
-import org.eclipse.jdt.core.search.SearchEngine
-import org.eclipse.jdt.internal.debug.ui.launcher.MainMethodSearchEngine
-import org.eclipse.jdt.core.IType
-import java.lang.reflect.InvocationTargetException
-import org.eclipse.jdt.internal.debug.ui.launcher.DebugTypeSelectionDialog
-import org.eclipse.jface.window.Window
-import org.eclipse.debug.core.ILaunchConfiguration
-import org.eclipse.core.resources.IWorkspace
-import org.eclipse.core.runtime.IStatus
-import org.eclipse.core.resources.IResource
-import com.ibm.icu.text.MessageFormat
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
-import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants
-import org.eclipse.core.runtime.CoreException
-import org.scalaide.core.IScalaPlugin
-import org.eclipse.core.runtime.IAdaptable
-import org.scalaide.core.internal.jdt.model.ScalaSourceFile
-import org.eclipse.ui.dialogs.FilteredResourcesSelectionDialog
-import org.eclipse.ui.dialogs.ResourceListSelectionDialog
-import org.eclipse.core.resources.IFile
-import org.eclipse.jdt.core.IPackageFragment
-import org.eclipse.ui.dialogs.ElementListSelectionDialog
-import org.eclipse.jface.viewers.LabelProvider
-import org.eclipse.core.resources.IProject
-import ScalaTestLaunchConstants._
-import org.eclipse.jface.viewers.TableViewer
-import org.eclipse.swt.SWT
-import org.eclipse.swt.widgets.TableColumn
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Group
 import org.eclipse.swt.widgets.Table
-import org.eclipse.jface.viewers.TableViewerColumn
+import org.eclipse.swt.widgets.TableColumn
 import org.eclipse.swt.widgets.TableItem
-import org.eclipse.swt.custom.TableEditor
-import org.eclipse.swt.events.SelectionAdapter
-import org.scalaide.core.IScalaProject
+import org.eclipse.swt.widgets.Text
+import org.eclipse.ui.PlatformUI
+import org.eclipse.ui.dialogs.ElementListSelectionDialog
+import org.eclipse.ui.dialogs.ResourceListSelectionDialog
+import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.internal.jdt.model.ScalaSourceFile
+
+import com.ibm.icu.text.MessageFormat
+
+import ScalaTestLaunchConstants._
 
 class ScalaTestMainTab extends SharedJavaMainTab {
   // UI widgets
@@ -106,11 +90,11 @@ class ScalaTestMainTab extends SharedJavaMainTab {
   private var fFileRadioButton: Button = null
   private var fPackageRadioButton: Button = null
   private var fIncludeNestedCheckBox: Button = null
-  
+
   private var testNamesGroup: Group = null
   private var fTestNamesTable: Table = null
   private var fTestNamesEditor: TableEditor = null
-  
+
   def createControl(parent: Composite) {
     val comp = SWTFactory.createComposite(parent, parent.getFont(), 1, 1, GridData.FILL_BOTH)
     comp.getLayout.asInstanceOf[GridLayout].verticalSpacing = 0
@@ -120,36 +104,34 @@ class ScalaTestMainTab extends SharedJavaMainTab {
     setControl(comp)
     PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), IJavaDebugHelpContextIds.LAUNCH_CONFIGURATION_DIALOG_MAIN_TAB)
   }
-  
+
   private def updateUI() {
     if (fSuiteRadioButton.getSelection) {
       fIncludeNestedCheckBox.setVisible(false)
       testNamesGroup.setVisible(true)
       mainGroup.setText("Suite Class")
-    }
-    else if (fFileRadioButton.getSelection) {
+    } else if (fFileRadioButton.getSelection) {
       fIncludeNestedCheckBox.setVisible(false)
       testNamesGroup.setVisible(false)
       mainGroup.setText("Suite File")
-    }
-    else {
+    } else {
       fIncludeNestedCheckBox.setVisible(true)
       testNamesGroup.setVisible(false)
       mainGroup.setText("Package Name")
     }
   }
-  
+
   val typeChangeListener = new SelectionListener() {
     override def widgetSelected(e: SelectionEvent) {
       updateUI
       fMainText.setText("")
     }
-    
+
     override def widgetDefaultSelected(e: SelectionEvent) {
       updateUI
     }
   }
-  
+
   override protected def createMainTypeEditor(parent: Composite, text: String) {
     val typeGroup = SWTFactory.createGroup(parent, "Type", 3, 1, GridData.FILL_HORIZONTAL)
     fSuiteRadioButton = SWTFactory.createRadioButton(typeGroup, "Suite")
@@ -161,106 +143,106 @@ class ScalaTestMainTab extends SharedJavaMainTab {
     fPackageRadioButton = SWTFactory.createRadioButton(typeGroup, "Package")
     fPackageRadioButton.addSelectionListener(getDefaultListener)
     fPackageRadioButton.addSelectionListener(typeChangeListener)
-    
-    mainGroup = SWTFactory.createGroup(parent, text, 2, 1, GridData.FILL_HORIZONTAL); 
+
+    mainGroup = SWTFactory.createGroup(parent, text, 2, 1, GridData.FILL_HORIZONTAL);
     fMainText = SWTFactory.createSingleText(mainGroup, 1);
     fMainText.addModifyListener(new ModifyListener() {
       def modifyText(e: ModifyEvent) {
         updateLaunchConfigurationDialog()
       }
     })
-    
+
     fSearchButton = createPushButton(mainGroup, LauncherMessages.AbstractJavaMainTab_2, null)
     fSearchButton.addSelectionListener(new SelectionListener() {
       def widgetDefaultSelected(e: SelectionEvent) {}
-	  def widgetSelected(e: SelectionEvent) {
+      def widgetSelected(e: SelectionEvent) {
         handleSearchButtonSelected();
       }
     })
     createMainTypeExtensions(mainGroup)
-    
+
     testNamesGroup = SWTFactory.createGroup(parent, "Test Names", 2, 1, GridData.FILL_BOTH)
     createTestNamesTable(testNamesGroup)
   }
-  
+
   override protected def createMainTypeExtensions(parent: Composite) {
     fIncludeNestedCheckBox = SWTFactory.createCheckButton(parent, "Include nested", null, false, 1)
     fIncludeNestedCheckBox.addSelectionListener(getDefaultListener)
   }
-  
+
   protected def createTestNamesTable(parent: Composite) {
     fTestNamesTable = new Table(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.BORDER)
     fTestNamesTable.setLayoutData(new GridData(GridData.FILL_BOTH))
-    
+
     val column1 = new TableColumn(fTestNamesTable, SWT.NONE)
-	column1.pack()
-	
-	fTestNamesEditor = new TableEditor(fTestNamesTable)
-	fTestNamesEditor.horizontalAlignment = SWT.LEFT
-	fTestNamesEditor.grabHorizontal = true
-	fTestNamesEditor.minimumWidth = 300
-	
-	fTestNamesTable.addSelectionListener(new SelectionAdapter() {
-	  override def widgetSelected(e: SelectionEvent) {
-	    val oldEditor = fTestNamesEditor.getEditor
-	    if (oldEditor != null)
-	      oldEditor.dispose()
-	      
-	      val item = e.item.asInstanceOf[TableItem]
-	      if (item == null)
-	        return
-	        
-	      val newEditor = new Text(fTestNamesTable, SWT.NONE)
-	      newEditor.setText(item.getText(0))
-	      newEditor.addModifyListener(new ModifyListener() {
-	        override def modifyText(me: ModifyEvent) {
-	          val text = fTestNamesEditor.getEditor.asInstanceOf[Text]
-	          fTestNamesEditor.getItem.setText(0, text.getText)
-	          updateLaunchConfigurationDialog()
-	        }
-	      })
-	      newEditor.selectAll()
-	      newEditor.setFocus()
-	      fTestNamesEditor.setEditor(newEditor, item, 0)
-	  }
-	})
-	
-	val comp = new Composite(parent, SWT.NONE)
-	val gridLayout = new GridLayout()
-	gridLayout.numColumns = 1
-	comp.setLayout(gridLayout)
-	comp.setLayoutData(new GridData(GridData.VERTICAL_ALIGN_BEGINNING))
-	
-	val addTestButton = createPushButton(comp, "Add", null)
-	addTestButton.addSelectionListener(new SelectionListener() {
+    column1.pack()
+
+    fTestNamesEditor = new TableEditor(fTestNamesTable)
+    fTestNamesEditor.horizontalAlignment = SWT.LEFT
+    fTestNamesEditor.grabHorizontal = true
+    fTestNamesEditor.minimumWidth = 300
+
+    fTestNamesTable.addSelectionListener(new SelectionAdapter() {
+      override def widgetSelected(e: SelectionEvent) {
+        val oldEditor = fTestNamesEditor.getEditor
+        if (oldEditor != null)
+          oldEditor.dispose()
+
+        val item = e.item.asInstanceOf[TableItem]
+        if (item == null)
+          return
+
+        val newEditor = new Text(fTestNamesTable, SWT.NONE)
+        newEditor.setText(item.getText(0))
+        newEditor.addModifyListener(new ModifyListener() {
+          override def modifyText(me: ModifyEvent) {
+            val text = fTestNamesEditor.getEditor.asInstanceOf[Text]
+            fTestNamesEditor.getItem.setText(0, text.getText)
+            updateLaunchConfigurationDialog()
+          }
+        })
+        newEditor.selectAll()
+        newEditor.setFocus()
+        fTestNamesEditor.setEditor(newEditor, item, 0)
+      }
+    })
+
+    val comp = new Composite(parent, SWT.NONE)
+    val gridLayout = new GridLayout()
+    gridLayout.numColumns = 1
+    comp.setLayout(gridLayout)
+    comp.setLayoutData(new GridData(GridData.VERTICAL_ALIGN_BEGINNING))
+
+    val addTestButton = createPushButton(comp, "Add", null)
+    addTestButton.addSelectionListener(new SelectionListener() {
       def widgetDefaultSelected(e: SelectionEvent) { widgetSelected(e) }
-	  def widgetSelected(e: SelectionEvent) {
+      def widgetSelected(e: SelectionEvent) {
         val item = new TableItem(fTestNamesTable, SWT.NONE)
         item.setText(Array[String]("[enter test name]"))
         updateLaunchConfigurationDialog()
       }
     })
-	
-	val removeTestButton = createPushButton(comp, "Remove", null)
-	removeTestButton.addSelectionListener(new SelectionListener() {
-	  def widgetDefaultSelected(e: SelectionEvent) { widgetSelected(e) }
-	  def widgetSelected(e: SelectionEvent) {
-	      val editor = fTestNamesEditor.getEditor
-	      if (editor != null)
-	        editor.dispose()
-	      fTestNamesTable.remove(fTestNamesTable.getSelectionIndices())
-	      fTestNamesTable.update()
-	      updateLaunchConfigurationDialog()
-	  }
-	})
+
+    val removeTestButton = createPushButton(comp, "Remove", null)
+    removeTestButton.addSelectionListener(new SelectionListener() {
+      def widgetDefaultSelected(e: SelectionEvent) { widgetSelected(e) }
+      def widgetSelected(e: SelectionEvent) {
+        val editor = fTestNamesEditor.getEditor
+        if (editor != null)
+          editor.dispose()
+        fTestNamesTable.remove(fTestNamesTable.getSelectionIndices())
+        fTestNamesTable.update()
+        updateLaunchConfigurationDialog()
+      }
+    })
   }
-  
+
   override def getImage = JavaUI.getSharedImages().getImage(ISharedImages.IMG_OBJS_CLASS);
-  
+
   def getName = LauncherMessages.JavaMainTab__Main_19
-  
+
   override def getId = "scala.tools.eclipse.launching.scalaTestMainTab"; //$NON-NLS-1$
-  
+
   protected def handleSearchButtonSelected() {
     val project = getJavaProject()
     var projects: Array[IJavaProject] = null
@@ -268,78 +250,80 @@ class ScalaTestMainTab extends SharedJavaMainTab {
       val model = JavaCore.create(ResourcesPlugin.getWorkspace.getRoot)
       if (model != null) {
         try {
-          projects = model.getJavaProjects.filter {jp: IJavaProject => IScalaPlugin().getScalaProject(jp.getProject()).hasScalaNature }
-        }
-        catch { case e: JavaModelException => JDIDebugUIPlugin.log(e) }
+          projects = model.getJavaProjects.filter { jp: IJavaProject => IScalaPlugin().getScalaProject(jp.getProject()).hasScalaNature }
+        } catch { case e: JavaModelException => JDIDebugUIPlugin.log(e) }
       }
-	}
-    else {
+    } else {
       projects = Array(project)
     }
     if (projects == null) {
       projects = Array.empty
     }
-    
+
     if (fSuiteRadioButton.getSelection) {
-      val types: Array[IType] = 
+      val types: Array[IType] =
         projects.flatMap { proj =>
-          for (file <- IScalaPlugin().getScalaProject(proj.getProject).allSourceFiles;
-            val ssf = ScalaSourceFile.createFromPath(file.getFullPath.toString); 
+          for (
+            file <- IScalaPlugin().getScalaProject(proj.getProject).allSourceFiles;
+            val ssf = ScalaSourceFile.createFromPath(file.getFullPath.toString);
             if ssf.isDefined;
             iType <- ssf.get.getAllTypes;
-            if ScalaTestLaunchShortcut.isScalaTestSuite(iType)) yield iType
+            if ScalaTestLaunchShortcut.isScalaTestSuite(iType)
+          ) yield iType
         }
-    
-      val mmsd = new DebugTypeSelectionDialog(getShell(), types, LauncherMessages.JavaMainTab_Choose_Main_Type_11) 
-	  mmsd.setTitle("ScalaTest Suite Selection")
-      if (mmsd.open() == Window.CANCEL) 
-	    return
-	
-      val results = mmsd.getResult	
+
+      val mmsd = new DebugTypeSelectionDialog(getShell(), types, LauncherMessages.JavaMainTab_Choose_Main_Type_11)
+      mmsd.setTitle("ScalaTest Suite Selection")
+      if (mmsd.open() == Window.CANCEL)
+        return
+
+      val results = mmsd.getResult
       val selectedType = results(0).asInstanceOf[IType]
       if (selectedType != null) {
         fMainText.setText(selectedType.getFullyQualifiedName())
         fProjText.setText(selectedType.getJavaProject().getElementName)
       }
-    }
-    else if (fFileRadioButton.getSelection) {
-      val files = 
+    } else if (fFileRadioButton.getSelection) {
+      val files =
         projects.flatMap { proj =>
-          for (file <- IScalaPlugin().getScalaProject(proj.getProject).allSourceFiles;
-            val ssf = ScalaSourceFile.createFromPath(file.getFullPath.toString); 
-            if ssf.isDefined && ScalaTestLaunchShortcut.containsScalaTestSuite(ssf.get)) yield file.asInstanceOf[IResource]
+          for (
+            file <- IScalaPlugin().getScalaProject(proj.getProject).allSourceFiles;
+            val ssf = ScalaSourceFile.createFromPath(file.getFullPath.toString);
+            if ssf.isDefined && ScalaTestLaunchShortcut.containsScalaTestSuite(ssf.get)
+          ) yield file.asInstanceOf[IResource]
         }
-      
+
       val fileSelectionDialog = new ResourceListSelectionDialog(getShell, files)
       fileSelectionDialog.setTitle("Scala Source File Selection")
-      if (fileSelectionDialog.open() == Window.CANCEL) 
+      if (fileSelectionDialog.open() == Window.CANCEL)
         return
-        
+
       val results = fileSelectionDialog.getResult
       val selectedFile = results(0).asInstanceOf[IFile]
       if (selectedFile != null) {
         fMainText.setText(selectedFile.getFullPath.toPortableString)
         fProjText.setText(selectedFile.getProject.getName)
       }
-    }
-    else if (fPackageRadioButton.getSelection) {
+    } else if (fPackageRadioButton.getSelection) {
       case class PackageOption(name: String, project: IJavaProject)
-      val packageSet = 
+      val packageSet =
         projects.flatMap { proj =>
-          for (file <- IScalaPlugin().getScalaProject(proj.getProject).allSourceFiles;
-            val ssf = ScalaSourceFile.createFromPath(file.getFullPath.toString); 
+          for (
+            file <- IScalaPlugin().getScalaProject(proj.getProject).allSourceFiles;
+            val ssf = ScalaSourceFile.createFromPath(file.getFullPath.toString);
             if ssf.isDefined;
             iType <- ssf.get.getAllTypes;
-            if ScalaTestLaunchShortcut.isScalaTestSuite(iType)) yield PackageOption(iType.getPackageFragment.getElementName, iType.getJavaProject)
-        }.toSet    
-      
+            if ScalaTestLaunchShortcut.isScalaTestSuite(iType)
+          ) yield PackageOption(iType.getPackageFragment.getElementName, iType.getJavaProject)
+        }.toSet
+
       val packageSelectionDialog = new ElementListSelectionDialog(getShell, new LabelProvider() { override def getText(element: Any) = element.asInstanceOf[PackageOption].name })
       packageSelectionDialog.setTitle("Package Selection")
       packageSelectionDialog.setMessage("Select a String (* = any string, ? = any char):")
       packageSelectionDialog.setElements(packageSet.toArray)
       if (packageSelectionDialog.open() == Window.CANCEL)
         return
-        
+
       val results = packageSelectionDialog.getResult
       val selectedPackageOption = results(0).asInstanceOf[PackageOption]
       if (selectedPackageOption != null) {
@@ -348,25 +332,25 @@ class ScalaTestMainTab extends SharedJavaMainTab {
       }
     }
   }
-  
+
   override def initializeFrom(config: ILaunchConfiguration) {
     super.initializeFrom(config)
     updateMainTypeFromConfig(config)
   }
-  
+
   override protected def updateMainTypeFromConfig(config: ILaunchConfiguration) {
     super.updateMainTypeFromConfig(config)
     val launchType = config.getAttribute(SCALATEST_LAUNCH_TYPE_NAME, TYPE_SUITE)
     launchType match {
-      case TYPE_SUITE => 
+      case TYPE_SUITE =>
         fSuiteRadioButton.setSelection(true)
         fFileRadioButton.setSelection(false)
         fPackageRadioButton.setSelection(false)
-      case TYPE_FILE => 
+      case TYPE_FILE =>
         fSuiteRadioButton.setSelection(false)
         fFileRadioButton.setSelection(true)
         fPackageRadioButton.setSelection(false)
-      case TYPE_PACKAGE => 
+      case TYPE_PACKAGE =>
         fSuiteRadioButton.setSelection(false)
         fFileRadioButton.setSelection(false)
         fPackageRadioButton.setSelection(true)
@@ -376,7 +360,7 @@ class ScalaTestMainTab extends SharedJavaMainTab {
       fIncludeNestedCheckBox.setSelection(true)
     else
       fIncludeNestedCheckBox.setSelection(false)
-    
+
     fTestNamesTable.removeAll()
     val rawTestSet = config.getAttributes.get(SCALATEST_LAUNCH_TESTS_NAME)
     val testSet: java.util.HashSet[String] = if (rawTestSet != null) rawTestSet.asInstanceOf[java.util.HashSet[String]] else new java.util.HashSet[String]()
@@ -385,10 +369,10 @@ class ScalaTestMainTab extends SharedJavaMainTab {
       val item = new TableItem(fTestNamesTable, SWT.NONE)
       item.setText(Array[String](testItr.next))
     }
-    
+
     updateUI()
   }
-  
+
   override def isValid(config: ILaunchConfiguration): Boolean = {
     setErrorMessage(null)
     setMessage(null)
@@ -397,18 +381,17 @@ class ScalaTestMainTab extends SharedJavaMainTab {
       val workspace = ResourcesPlugin.getWorkspace
       val status = workspace.validateName(name, IResource.PROJECT)
       if (status.isOK) {
-        val project= ResourcesPlugin.getWorkspace.getRoot.getProject(name)
+        val project = ResourcesPlugin.getWorkspace.getRoot.getProject(name)
         if (!project.exists()) {
           setErrorMessage(MessageFormat.format(LauncherMessages.JavaMainTab_20, Array(name)))
           return false
         }
-	    if (!project.isOpen) {
-          setErrorMessage(MessageFormat.format(LauncherMessages.JavaMainTab_21, Array(name))) 
+        if (!project.isOpen) {
+          setErrorMessage(MessageFormat.format(LauncherMessages.JavaMainTab_21, Array(name)))
           return false
         }
-      }
-      else {
-        setErrorMessage(MessageFormat.format(LauncherMessages.JavaMainTab_19, Array(status.getMessage()))) 
+      } else {
+        setErrorMessage(MessageFormat.format(LauncherMessages.JavaMainTab_19, Array(status.getMessage())))
         return false
       }
     }
@@ -418,43 +401,41 @@ class ScalaTestMainTab extends SharedJavaMainTab {
         setErrorMessage("Suite Class cannot be empty.")
       else if (fFileRadioButton.getSelection)
         setErrorMessage("Suite File cannot be empty.")
-     else
+      else
         setErrorMessage("Package Name cannot be empty.")
       return false
     }
     return true
   }
-  
+
   def performApply(config: ILaunchConfigurationWorkingCopy) {
-    val launchType = 
+    val launchType =
       if (fSuiteRadioButton.getSelection)
         TYPE_SUITE
       else if (fFileRadioButton.getSelection)
         TYPE_FILE
       else
-        TYPE_PACKAGE 
+        TYPE_PACKAGE
     val includeNested = if (fIncludeNestedCheckBox.getSelection) INCLUDE_NESTED_TRUE else INCLUDE_NESTED_FALSE
-    
+
     val testNameSet = new java.util.HashSet[String]()
     val items = fTestNamesTable.getItems
     items.foreach(i => testNameSet.add(i.getText(0)))
-    
-    val configMap = new java.util.HashMap[String, Any]()
-    configMap.put(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText.trim)
-    configMap.put(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, fMainText.getText.trim) 
-    configMap.put(SCALATEST_LAUNCH_TYPE_NAME, launchType) 
-    configMap.put(SCALATEST_LAUNCH_INCLUDE_NESTED_NAME, includeNested) 
-    configMap.put(SCALATEST_LAUNCH_TESTS_NAME, testNameSet)
-    
-    config.setAttributes(configMap)
+
+    config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProjText.getText.trim)
+    config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, fMainText.getText.trim)
+    config.setAttribute(SCALATEST_LAUNCH_TYPE_NAME, launchType)
+    config.setAttribute(SCALATEST_LAUNCH_INCLUDE_NESTED_NAME, includeNested)
+    config.setAttribute(SCALATEST_LAUNCH_TESTS_NAME, testNameSet)
+
     mapResources(config)
   }
-  
+
   def setDefaults(config: ILaunchConfigurationWorkingCopy) {
     val javaElement = getContext
-    if (javaElement != null) 
+    if (javaElement != null)
       initializeJavaProject(javaElement, config)
-    else 
+    else
       config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, "")
     initializeMainTypeAndName(javaElement, config)
     config.setAttribute(SCALATEST_LAUNCH_TYPE_NAME, TYPE_SUITE)

--- a/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestScalaLaunchDelegate.scala
+++ b/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/launching/ScalaTestScalaLaunchDelegate.scala
@@ -1,0 +1,7 @@
+package scala.tools.eclipse.scalatest.launching
+
+import org.scalaide.debug.internal.launching.ScalaDebuggerForLaunchDelegate
+
+class ScalaTestScalaLaunchDelegate extends ScalaTestLaunchDelegate with ScalaDebuggerForLaunchDelegate {
+  override protected def addToVmRunnerClasspath(classpath: Seq[String]): Array[String] = classpath.toArray
+}

--- a/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/ui/ScalaTestRunnerViewPart.scala
+++ b/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/ui/ScalaTestRunnerViewPart.scala
@@ -917,7 +917,8 @@ class ScalaTestRunnerViewPart extends ViewPart with Observer {
     override def run() {
       val launch = session.fLaunch
       val delegate = new ScalaTestLaunchDelegate()
-      val stArgs = delegate.getScalaTestArgsForFailedTests(session.rootNode)
+      import ScalaTestLaunchDelegate._
+      val stArgs = getScalaTestArgsForFailedTests(session.rootNode)
       val buildBeforeLaunch = DebugUIPlugin.getDefault().getPreferenceStore().getBoolean(IDebugUIConstants.PREF_BUILD_BEFORE_LAUNCH)
       if (buildBeforeLaunch)
         ScalaTestPlugin.doBuild()

--- a/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/ui/ScalaTestViewer.scala
+++ b/org.scala-ide.sdt.scalatest/src/scala/tools/eclipse/scalatest/ui/ScalaTestViewer.scala
@@ -736,7 +736,7 @@ private class RerunSuiteAction(actionName: String, fTestRunnerPart: ScalaTestRun
                                suiteId: String) extends Action(actionName) {
   override def run() {
     val delegate = new ScalaTestLaunchDelegate()
-    val stArgs = delegate.getScalaTestArgsForSuite(suiteClassName, suiteId)
+    val stArgs = ScalaTestLaunchDelegate.getScalaTestArgsForSuite(suiteClassName, suiteId)
     rerun(fTestRunnerPart, delegate, stArgs)
   }
 }
@@ -745,7 +745,7 @@ private class RerunTestAction(actionName: String, fTestRunnerPart: ScalaTestRunn
                                suiteId: String, testName: String) extends Action(actionName) {
   override def run() {
     val delegate = new ScalaTestLaunchDelegate()
-    val stArgs = delegate.getScalaTestArgsForTest(suiteClassName, suiteId, testName)
+    val stArgs = ScalaTestLaunchDelegate.getScalaTestArgsForTest(suiteClassName, suiteId, testName)
     rerun(fTestRunnerPart, delegate, stArgs)
   }
 }


### PR DESCRIPTION
currently the scalatest launcher uses standard java vm runner
to run or debug tests. It works fine with a java expression
evaluator but with the Scala IDE 4.1.0 there is available the
Scala Expression Evaluator which requires a Scala Debugger.
This enhancement adds a new scala launcher. From now it is
possible to choose appropriate launcher:
- an old java one especially for java projects where tests are written
  with scalatest. Then debugging and evaluation can be done with a java
  evaluator
- a new scala one for scala projects (can be used for java projects as
  well but is not documented).
  You can stop in breakpoint during a test execution and evaluate
  arbitrary expression.

This PR must be taken with scala-ide PR #955

Fix #52 
