### PR TITLE
Update eclipse feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .settings/
 .classpath
 bin/
+.cache*
 

--- a/org.scala-ide.sdt.scalatest.feature/feature.xml
+++ b/org.scala-ide.sdt.scalatest.feature/feature.xml
@@ -57,7 +57,7 @@ SUCH DAMAGE.
    </url>
 
    <requires>
-      <import feature="org.scala-ide.sdt.feature" version="4.0.0" match="compatible"/>
+      <import feature="org.scala-ide.sdt.feature" version="4.2.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
For some reason, our build server failed to build the ecosystem because the Eclipse feature is outdated. Beside from updating the feature I also changed the match property, in hope that in future when we forget to update it again it does not break the build.

After this is merged, if you @cheeseng could publish an updated release of the plugin, otherwise we can't build the ecosystem.

\cc @dragos, @wpopielarski
