### PR TITLE
Revert change from `greaterOrEqual` back to `compatible`

### DIFF
--- a/org.scala-ide.sdt.scalatest.feature/feature.xml
+++ b/org.scala-ide.sdt.scalatest.feature/feature.xml
@@ -57,7 +57,7 @@ SUCH DAMAGE.
    </url>
 
    <requires>
-      <import feature="org.scala-ide.sdt.feature" version="4.2.0" match="greaterOrEqual"/>
+      <import feature="org.scala-ide.sdt.feature" version="4.2.0" match="compatible"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
This change wasn't that great, since it means that this plugin could
also be used in a Scala IDE 5.0, which may or may not work. With an
update of the major Scala IDE version, this plugin would have to be
revisited anyway.

Furthermore, the Scala IDE ecosystem doesn't support the `greaterOrEqual`
property right now. With `greaterOrEqual` the generated range is
"4.2.0", whereas with `compatible` it is "[4.2.0,5.0.0)". The former one
just can't be handled by the ecosystem and I don't know how to fix it.

Fixes #56
